### PR TITLE
Kong integration with wsk and task subcommands

### DIFF
--- a/nuv/cli.go
+++ b/nuv/cli.go
@@ -1,0 +1,16 @@
+package main
+
+type CLI struct {
+	WskCLI
+	TaskCLI
+}
+
+type WskCLI struct {
+	Wsk struct {
+	} `cmd:"" help:"wsk subcommand."`
+}
+
+type TaskCLI struct {
+	Task struct {
+	} `cmd:"" help:"task subcommand."`
+}

--- a/nuv/cli.go
+++ b/nuv/cli.go
@@ -1,16 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
 package main
 
+import cmds "github.com/nuvolaris/nuvolaris-cli/nuv/commands"
+
 type CLI struct {
-	WskCLI
-	TaskCLI
-}
-
-type WskCLI struct {
-	Wsk struct {
-	} `cmd:"" help:"wsk subcommand."`
-}
-
-type TaskCLI struct {
-	Task struct {
-	} `cmd:"" help:"task subcommand."`
+	Wsk  cmds.WskCmd  `cmd:"" help:"wsk subcommand."`
+	Task cmds.TaskCmd `cmd:"" help:"task subcommand."`
 }

--- a/nuv/commands/task.go
+++ b/nuv/commands/task.go
@@ -39,7 +39,7 @@ type TaskCmd struct {
 	Silent      bool   `help:"disables echoing" short:"s"`
 	Status      bool   `help:"exits with non-zero exit code if any of the given tasks is not up-to-date"`
 	Summary     bool   `help:"show summary about a task"`
-	Taskfile    string `help:"choose which Taskfile to run. Defaults to Taskfile.yml"`
+	Taskfile    string `help:"choose which Taskfile to run. Defaults to Taskfile.yml" type:"existingfile"`
 	Verbose     bool   `help:"enables verbose mode" short:"v"`
 	Version     bool   `help:"show Task version"`
 	Watch       bool   `help:"enables watch of the given task" short:"w"`

--- a/nuv/commands/task.go
+++ b/nuv/commands/task.go
@@ -31,7 +31,6 @@ type TaskCmd struct {
 	Dir         string `help:"sets directory of execution" short:"d"`
 	Dry         bool   `help:"compiles and prints tasks in the order that they would be run, without executing them"`
 	Force       bool   `help:"forces execution even when the task is up-to-date" short:"f"`
-	Help        bool   `help:"shows Task usage" short:"h"`
 	Init        bool   `help:"creates a new Taskfile.yml in the current folder" short:"i"`
 	List        bool   `help:"lists tasks with description of current Taskfile" short:"l"`
 	Output      string `help:"sets output style: [interleaved|group|prefixed]" short:"o"`
@@ -43,6 +42,7 @@ type TaskCmd struct {
 	Verbose     bool   `help:"enables verbose mode" short:"v"`
 	Version     bool   `help:"show Task version"`
 	Watch       bool   `help:"enables watch of the given task" short:"w"`
+	// Help        bool   `help:"" short:"h"`
 }
 
 func (t *TaskCmd) Run() error {

--- a/nuv/commands/task.go
+++ b/nuv/commands/task.go
@@ -15,14 +15,33 @@
 // specific language governing permissions and limitations
 // under the License.
 //
-package main
+package commands
 
 import (
-	"github.com/alecthomas/kong"
+	"context"
+	"fmt"
+
+	"github.com/go-task/task/v3"
+	"github.com/go-task/task/v3/taskfile"
 )
 
-func main() {
-	ctx := kong.Parse(&CLI{})
-	err := ctx.Run()
-	ctx.FatalIfErrorf(err)
+type TaskCmd struct {
+}
+
+func (t *TaskCmd) Run() error {
+	runTaskInteractionSample()
+	return nil
+}
+
+func runTaskInteractionSample() {
+	fmt.Println("Doing something with task...")
+
+	te := task.Executor{}
+	err := te.Setup()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	te.RunTask(context.Background(), taskfile.Call{Task: "setup"})
 }

--- a/nuv/commands/task.go
+++ b/nuv/commands/task.go
@@ -26,6 +26,23 @@ import (
 )
 
 type TaskCmd struct {
+	Color       bool   `help:"colored output. Enabled by default. Set flag to false or use NO_COLOR=1 to disable (default true)" default:"true" short:"c" env:"NO_COLOR"`
+	Concurrency int    `help:"limit number tasks to run concurrently" short:"C"`
+	Dir         string `help:"sets directory of execution" short:"d"`
+	Dry         bool   `help:"compiles and prints tasks in the order that they would be run, without executing them"`
+	Force       bool   `help:"forces execution even when the task is up-to-date" short:"f"`
+	Help        bool   `help:"shows Task usage" short:"h"`
+	Init        bool   `help:"creates a new Taskfile.yml in the current folder" short:"i"`
+	List        bool   `help:"lists tasks with description of current Taskfile" short:"l"`
+	Output      string `help:"sets output style: [interleaved|group|prefixed]" short:"o"`
+	Parallel    bool   `help:"executes tasks provided on command line in parallel" short:"p"`
+	Silent      bool   `help:"disables echoing" short:"s"`
+	Status      bool   `help:"exits with non-zero exit code if any of the given tasks is not up-to-date"`
+	Summary     bool   `help:"show summary about a task"`
+	Taskfile    string `help:"choose which Taskfile to run. Defaults to Taskfile.yml"`
+	Verbose     bool   `help:"enables verbose mode" short:"v"`
+	Version     bool   `help:"show Task version"`
+	Watch       bool   `help:"enables watch of the given task" short:"w"`
 }
 
 func (t *TaskCmd) Run() error {

--- a/nuv/commands/task.go
+++ b/nuv/commands/task.go
@@ -42,7 +42,6 @@ type TaskCmd struct {
 	Verbose     bool   `help:"enables verbose mode" short:"v"`
 	Version     bool   `help:"show Task version"`
 	Watch       bool   `help:"enables watch of the given task" short:"w"`
-	// Help        bool   `help:"" short:"h"`
 }
 
 func (t *TaskCmd) Run() error {

--- a/nuv/commands/wsk.go
+++ b/nuv/commands/wsk.go
@@ -26,6 +26,14 @@ import (
 )
 
 type WskCmd struct {
+	Apihost    string `help:"whisk API HOST" short:"C"`
+	Apiversion string `help:"whisk API VERSION"`
+	Auth       string `help:"authorization KEY" short:"u"`
+	Cert       string `help:"client cert"`
+	Debug      bool   `help:"debug level output" short:"d"`
+	Insecure   bool   `help:"bypass certificate checking" short:"i"`
+	Key        string `help:"client key"`
+	Verbose    bool   `help:"verbose output" short:"v"`
 }
 
 func (wsk *WskCmd) Run() error {
@@ -36,7 +44,10 @@ func (wsk *WskCmd) Run() error {
 func runWskApiInteractionSample() {
 	fmt.Println("Doing something with wsk...")
 
-	client, err := whisk.NewClient(http.DefaultClient, nil)
+	client, err := whisk.NewClient(http.DefaultClient, &whisk.Config{
+		Host:      "",
+		AuthToken: "",
+	})
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(-1)

--- a/nuv/commands/wsk.go
+++ b/nuv/commands/wsk.go
@@ -15,14 +15,46 @@
 // specific language governing permissions and limitations
 // under the License.
 //
-package main
+package commands
 
 import (
-	"github.com/alecthomas/kong"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/apache/openwhisk-client-go/whisk"
 )
 
-func main() {
-	ctx := kong.Parse(&CLI{})
-	err := ctx.Run()
-	ctx.FatalIfErrorf(err)
+type WskCmd struct {
+}
+
+func (wsk *WskCmd) Run() error {
+	runWskApiInteractionSample()
+	return nil
+}
+
+func runWskApiInteractionSample() {
+	fmt.Println("Doing something with wsk...")
+
+	client, err := whisk.NewClient(http.DefaultClient, nil)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
+
+	options := &whisk.ActionListOptions{
+		Limit: 10,
+		Skip:  0,
+	}
+
+	fmt.Printf("Retrieving actions list...  \n")
+
+	actions, resp, err := client.Actions.List("", options)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
+
+	fmt.Println("Returned with status: ", resp.Status)
+	fmt.Printf("Returned actions: \n %+v", actions)
 }

--- a/nuv/commands/wsk.go
+++ b/nuv/commands/wsk.go
@@ -34,6 +34,19 @@ type WskCmd struct {
 	Insecure   bool   `help:"bypass certificate checking" short:"i"`
 	Key        string `help:"client key"`
 	Verbose    bool   `help:"verbose output" short:"v"`
+
+	Action     struct{} `cmd:"" help:"wsk action subcommand."`
+	Activation struct{} `cmd:"" help:"wsk activation subcommand."`
+	Api        struct{} `cmd:"" help:"wsk api subcommand."`
+	Help       struct{} `cmd:"" help:"wsk help subcommand."`
+	List       struct{} `cmd:"" help:"wsk list subcommand."`
+	Namespace  struct{} `cmd:"" help:"wsk namespace subcommand."`
+	Package    struct{} `cmd:"" help:"wsk package subcommand."`
+	Project    struct{} `cmd:"" help:"wsk project subcommand."`
+	Property   struct{} `cmd:"" help:"wsk property subcommand."`
+	Rule       struct{} `cmd:"" help:"wsk rule subcommand."`
+	Sdk        struct{} `cmd:"" help:"wsk sdk subcommand."`
+	Trigger    struct{} `cmd:"" help:"wsk trigger subcommand."`
 }
 
 func (wsk *WskCmd) Run() error {

--- a/nuv/go.mod
+++ b/nuv/go.mod
@@ -22,6 +22,7 @@ go 1.17
 replace github.com/go-task/task/v3 => ../task
 
 require (
+	github.com/alecthomas/kong v0.2.22
 	github.com/apache/openwhisk-client-go v0.0.0-20211007130743-38709899040b
 	github.com/go-task/task/v3 v3.9.2
 )
@@ -39,6 +40,7 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/nicksnyder/go-i18n v1.10.1 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/radovskyb/watcher v1.0.7 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect

--- a/nuv/go.sum
+++ b/nuv/go.sum
@@ -1,4 +1,8 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/alecthomas/kong v0.2.22 h1:lRcQYT2/yJ+coDNA5ws0mRL0pwSqjbP/6AcRkyKhomk=
+github.com/alecthomas/kong v0.2.22/go.mod h1:uzxf/HUh0tj43x1AyJROl3JT7SgsZ5m+icOv1csRhc0=
+github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142 h1:8Uy0oSf5co/NZXje7U1z8Mpep++QJOldL2hs/sBQf48=
+github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
 github.com/apache/openwhisk-client-go v0.0.0-20211007130743-38709899040b h1:E0IprB8sveEHNP3WiZB/N/3nWzljyQCIDYFg0N3geGU=
 github.com/apache/openwhisk-client-go v0.0.0-20211007130743-38709899040b/go.mod h1:SAQU4bHGJ0sg6c1vQ8ojmQKXgGaneVnexWX4+2/KMr8=
 github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21 h1:tuijfIjZyjZaHq9xDUh0tNitwXshJpbLkqMOJv4H3do=
@@ -77,6 +81,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/nuv/main.go
+++ b/nuv/main.go
@@ -27,6 +27,10 @@ func main() {
 		kong.Name("nuv"),
 		kong.Description("TODO a description for nuv"),
 		kong.UsageOnError(),
+		kong.ConfigureHelp(kong.HelpOptions{
+			Compact:             true,
+			NoExpandSubcommands: true,
+		}),
 	)
 	err := ctx.Run()
 	ctx.FatalIfErrorf(err)

--- a/nuv/main.go
+++ b/nuv/main.go
@@ -22,7 +22,12 @@ import (
 )
 
 func main() {
-	ctx := kong.Parse(&CLI{})
+	cli := CLI{}
+	ctx := kong.Parse(&cli,
+		kong.Name("nuv"),
+		kong.Description("TODO a description for nuv"),
+		kong.UsageOnError(),
+	)
 	err := ctx.Run()
 	ctx.FatalIfErrorf(err)
 }

--- a/nuv/main.go
+++ b/nuv/main.go
@@ -23,25 +23,11 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/alecthomas/kong"
 	"github.com/apache/openwhisk-client-go/whisk"
 	"github.com/go-task/task/v3"
 	"github.com/go-task/task/v3/taskfile"
-
-	"github.com/alecthomas/kong"
 )
-
-var CLI struct {
-	Wsk struct {
-		Force     bool `help:"Force removal."`
-		Recursive bool `help:"Recursively remove files."`
-
-		Paths []string `arg:"" name:"path" help:"Paths to remove." type:"path"`
-	} `cmd:"" help:"Remove files."`
-
-	Task struct {
-		Paths []string `arg:"" optional:"" name:"path" help:"Paths to list." type:"path"`
-	} `cmd:"" help:"List paths."`
-}
 
 func runTaskInteractionSample() {
 	fmt.Println("Doing something with task...")
@@ -83,15 +69,15 @@ func runWskApiInteractionSample() {
 }
 
 func main() {
-	ctx := kong.Parse(&CLI)
+	ctx := kong.Parse(&CLI{})
 
 	switch ctx.Command() {
-	case "wsk <path>":
+	case "wsk":
+		runWskApiInteractionSample()
 	case "task":
+		runTaskInteractionSample()
 	default:
 		panic(ctx.Command())
 	}
 
-	runTaskInteractionSample()
-	runWskApiInteractionSample()
 }

--- a/nuv/main.go
+++ b/nuv/main.go
@@ -26,7 +26,22 @@ import (
 	"github.com/apache/openwhisk-client-go/whisk"
 	"github.com/go-task/task/v3"
 	"github.com/go-task/task/v3/taskfile"
+
+	"github.com/alecthomas/kong"
 )
+
+var CLI struct {
+	Wsk struct {
+		Force     bool `help:"Force removal."`
+		Recursive bool `help:"Recursively remove files."`
+
+		Paths []string `arg:"" name:"path" help:"Paths to remove." type:"path"`
+	} `cmd:"" help:"Remove files."`
+
+	Task struct {
+		Paths []string `arg:"" optional:"" name:"path" help:"Paths to list." type:"path"`
+	} `cmd:"" help:"List paths."`
+}
 
 func runTaskInteractionSample() {
 	fmt.Println("Doing something with task...")
@@ -68,6 +83,15 @@ func runWskApiInteractionSample() {
 }
 
 func main() {
+	ctx := kong.Parse(&CLI)
+
+	switch ctx.Command() {
+	case "wsk <path>":
+	case "task":
+	default:
+		panic(ctx.Command())
+	}
+
 	runTaskInteractionSample()
 	runWskApiInteractionSample()
 }


### PR DESCRIPTION
This PR adds Kong for the cli (#4) and adds the basis for the wsk and task subcommands,
using the subcommand Run() approach as defined in the [kong readme](https://github.com/alecthomas/kong#attach-a-run-error-method-to-each-command).

As of now `nuv wsk` and `nuv task` run the integration examples previously added, I will keep adding to this PR so the status of the work can be tracked.