### PR TITLE
Fix load .wskprops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ kubeconfig
 nuvolaris.yml
 .task/
 vendor/
+.idea

--- a/nuv/go.mod
+++ b/nuv/go.mod
@@ -33,6 +33,8 @@ require (
 	github.com/go-task/task/cmd/task v0.0.0-00010101000000-000000000000
 	github.com/nicksnyder/go-i18n v1.10.1
 	github.com/stretchr/testify v1.7.0
+	k8s.io/api v0.23.3
+	k8s.io/client-go v0.23.3
 	sigs.k8s.io/kind v0.11.1
 )
 
@@ -56,8 +58,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	k8s.io/api v0.23.3 // indirect
-	k8s.io/client-go v0.23.3 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect
@@ -99,7 +99,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiextensions-apiserver v0.23.3
-	k8s.io/apimachinery v0.23.3 // indirect
+	k8s.io/apimachinery v0.23.3
 	mvdan.cc/sh/v3 v3.4.2 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/nuv/wsk_properties.go
+++ b/nuv/wsk_properties.go
@@ -24,7 +24,7 @@ import (
 )
 
 const wsk_auth = "23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP"
-const wsk_apihost = "https://localhost:3233"
+const wsk_apihost = "http://localhost:3233"
 
 func writeWskPropertiesFile() error {
 	homedir, err := GetHomeDir()


### PR DESCRIPTION
Hi, i tried your CLI on macos envinroment. After the installation of devcluster and then the setup of nuvolaris, i ran into two problems whan i tried to run the subcommand wsk:

1)  Parameter **apihost** is missing.

I have seen that the cli generates the file .wskprops under the folder /${HOME}/.nuvolaris whereas wsk expects to find it in /${HOME}. So i have implemented a manual parsing of the file under .nuvolaris folder and then push the arguments **apihost** and **auth** into the final wsk command as arguments.

2)  apihost mapped as https instead of http

I changed the constant wsk_apihost

I wanna emphasize that i am not a expert of openwhisk and i could have missed some steps during  the suggested configuration that has generated these two issues which i have reported above.

PS: very cool project 👍 

