### PR TITLE
Small setupNuvolaris refactor

### DIFF
--- a/nuv/setup.go
+++ b/nuv/setup.go
@@ -18,9 +18,9 @@
 package main
 
 type SetupCmd struct {
-	Devcluster bool   `help:"start dev kind k8s cluster"`
+	Devcluster bool   `help:"start dev kind k8s cluster" xor:"dev-or-reset"`
 	ImageTag   string `default:"neo-22.0207.21" help:"nuvolaris operator docker image tag to deploy"`
-	Reset      bool   `help:"reset nuvolaris setup"`
+	Reset      bool   `help:"reset nuvolaris setup" xor:"dev-or-reset"`
 }
 
 func (setupCmd *SetupCmd) Run() error {

--- a/nuv/setup_nuvolaris.go
+++ b/nuv/setup_nuvolaris.go
@@ -31,7 +31,6 @@ type SetupPipeline struct {
 type setupStep func(sp *SetupPipeline)
 
 func (sp *SetupPipeline) step(f setupStep) {
-
 	if sp.err != nil {
 		return
 	}
@@ -46,14 +45,9 @@ func setupNuvolaris(cmd *SetupCmd) error {
 		operatorDockerImage: "ghcr.io/nuvolaris/nuvolaris-operator:" + imgTag,
 	}
 
-	if cmd.Devcluster {
-		sp.createDevcluster = true
-	}
+	sp.createDevcluster = cmd.Devcluster
 
-	if sp.kubeClient == nil {
-		sp.step(assertNuvolarisClusterConfig)
-	}
-
+	sp.step(assertNuvolarisClusterConfig)
 	if cmd.Reset {
 		sp.step(resetNuvolaris)
 	} else {


### PR DESCRIPTION
A small change to simplify setupNuvolaris funciton

Devcluster flag is already a boolean so it could be directly assigned to createDevcluster field
and the condiction `sp.kubeClient == nil` is always true because the pipeline is created a few lines above
without assigning to kubeClient.