### PR TITLE
Use kong interpolation and constant convention

### DIFF
--- a/nuv/Taskfile.yml
+++ b/nuv/Taskfile.yml
@@ -27,7 +27,7 @@ tasks:
 
   build:
     cmds:
-      - go build -ldflags "-X main.CLI_VERSION={{.TAG}}" -o ./nuv
+      - go build -ldflags "-X main.CLIVersion={{.TAG}}" -o ./nuv
     sources:
       - "*.go"
       - "embed/*"
@@ -53,7 +53,7 @@ tasks:
     deps:
       - vendor
     cmds:
-      - go build -gcflags '-N -l' -mod=vendor -ldflags "-X main.CLI_VERSION={{.TAG}}" -o {{.NUV}}-debug
+      - go build -gcflags '-N -l' -mod=vendor -ldflags "-X main.CLIVersion={{.TAG}}" -o {{.NUV}}-debug
     generates:
       - "{{.NUV}}-debug"
 

--- a/nuv/main.go
+++ b/nuv/main.go
@@ -23,7 +23,11 @@ import (
 
 // CLI_VERSION holds the current version, to be set by the build with
 //  go build -ldflags "-X main.CLI_VERSION=<version>"
-var CLI_VERSION string = "latest"
+const CLI_VERSION string = "latest"
+
+// ImageTag holds the version of the Docker image used for the nuvolaris
+// operator used in setup
+const ImageTag string = "neo-22.0207.21"
 
 type CLI struct {
 	Deploy     DeployCmd     `cmd:"" help:"deploy a nuvolaris cluster"`
@@ -49,7 +53,10 @@ func main() {
 			Compact:             true,
 			NoExpandSubcommands: false,
 		}),
-		kong.Vars{"version": CLI_VERSION},
+		kong.Vars{
+			"version":   CLI_VERSION,
+			"image_tag": ImageTag,
+		},
 	)
 	err := ctx.Run()
 	ctx.FatalIfErrorf(err)

--- a/nuv/main.go
+++ b/nuv/main.go
@@ -21,9 +21,9 @@ import (
 	"github.com/alecthomas/kong"
 )
 
-// CLI_VERSION holds the current version, to be set by the build with
-//  go build -ldflags "-X main.CLI_VERSION=<version>"
-const CLI_VERSION string = "latest"
+// CLIVersion holds the current version, to be set by the build with
+//  go build -ldflags "-X main.CLIVersion=<version>"
+const CLIVersion string = "latest"
 
 // ImageTag holds the version of the Docker image used for the nuvolaris
 // operator used in setup
@@ -54,7 +54,7 @@ func main() {
 			NoExpandSubcommands: false,
 		}),
 		kong.Vars{
-			"version":   CLI_VERSION,
+			"version":   CLIVersion,
 			"image_tag": ImageTag,
 		},
 	)

--- a/nuv/setup.go
+++ b/nuv/setup.go
@@ -19,7 +19,7 @@ package main
 
 type SetupCmd struct {
 	Devcluster bool   `help:"start dev kind k8s cluster" xor:"dev-or-reset"`
-	ImageTag   string `default:"neo-22.0207.21" help:"nuvolaris operator docker image tag to deploy"`
+	ImageTag   string `default:"${image_tag}" help:"nuvolaris operator docker image tag to deploy"`
 	Reset      bool   `help:"reset nuvolaris setup" xor:"dev-or-reset"`
 }
 

--- a/nuv/wsk.go
+++ b/nuv/wsk.go
@@ -43,7 +43,7 @@ func init() {
 	T = wski18n.T
 
 	// Rest of CLI uses the Properties struct, so set the build time there
-	commands.Properties.CLIVersion = CLI_VERSION
+	commands.Properties.CLIVersion = CLIVersion
 }
 
 func (w *WskCmd) BeforeApply() error {


### PR DESCRIPTION
This PR changes the image tag field in setup with the field interpolation implemented in Kong so that the value is
in main with the cli version constant, making it easier to read and modify.

It also changes the constant CLI_VERSION to CLIVersion so it respects the convention of Go where constants use MixedCaps. 