### PR TITLE
Fix dev cluster creation in container

### DIFF
--- a/nuv/devcluster.go
+++ b/nuv/devcluster.go
@@ -22,11 +22,6 @@ type DevClusterCmd struct {
 }
 
 func (devClusterCmd *DevClusterCmd) Run() error {
-	// kind does not work using the socat proxy that VSCode, it needs a workaround when running nuv
-	if ExecutingInContainer() && DockerHostEmpty() {
-		DockerHostDevcluster()
-		return nil
-	}
 	config, err := configKind()
 	if err != nil {
 		return err

--- a/nuv/kind.go
+++ b/nuv/kind.go
@@ -29,6 +29,9 @@ type KindCmd struct {
 
 func Kind(args ...string) error {
 	os.Args = append([]string{"kind"}, args...)
+	if ExecutingInContainer() && DockerHostEmpty() {
+		return DockerHostKind()
+	}
 	app.Main()
 	return nil
 }

--- a/nuv/util.go
+++ b/nuv/util.go
@@ -144,17 +144,24 @@ func ExecutingInContainer() bool {
 	return true
 }
 
-func DockerHostDevcluster() error {
-	args := append([]string{"env", "DOCKER_HOST=unix:///var/run/docker-host.sock"}, os.Args...)
-	cmd := exec.Command("sudo", args...)
+func DockerHostKind() error {
+	if os.Args[1] == "create" || os.Args[1] == "delete" {
+		appendKubeConfig()
+	}
+	os.Args = append([]string{"env", "DOCKER_HOST=unix:///var/run/docker-host.sock"}, os.Args...)
+	cmd := exec.Command("sudo", os.Args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("err %s", err.Error())
-	}
-	return nil
+	err := cmd.Run()
+	return err
 }
 
 func DockerHostEmpty() bool {
 	return len(os.Getenv("DOCKER_HOST")) == 0
+}
+
+func appendKubeConfig() {
+	homedir, _ := GetHomeDir()
+	kc := filepath.Join(homedir, ".kube/config")
+	os.Args = append(os.Args, "--kubeconfig="+kc)
 }


### PR DESCRIPTION
Previously the creation of the container worked  only for the devcluster cmd, but creating the cluster with nuv setup --devcluster didn't work cause kind wasn't being forked.
This PR moves the logic to reexecute kind directly + fixes a problem where creating the cluster was setting the kubeconfig in /root/.kube/config instead or ~/.kube/config. That meant nuv couldnt see the cluster after creation.