### PR TITLE
S3 command

### DIFF
--- a/nuv/main.go
+++ b/nuv/main.go
@@ -39,6 +39,7 @@ type CLI struct {
 	Devcluster DevClusterCmd `cmd:"" help:"create or destroy kind k8s cluster"`
 	Setup      SetupCmd      `cmd:"" help:"setup nuvolaris"`
 	Scan       ScanCmd       `cmd:"" help:"scan subcommand"`
+	S3         S3Cmd         `cmd:"" name:"s3" help:"s3 subcommand"`
 
 	Version kong.VersionFlag `short:"v" help:"show nuvolaris version"`
 }

--- a/nuv/main.go
+++ b/nuv/main.go
@@ -52,7 +52,7 @@ func main() {
 		kong.UsageOnError(),
 		kong.ConfigureHelp(kong.HelpOptions{
 			Compact:             true,
-			NoExpandSubcommands: false,
+			NoExpandSubcommands: true,
 		}),
 		kong.Vars{
 			"version":   CLIVersion,

--- a/nuv/s3.go
+++ b/nuv/s3.go
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package main
+
+import "fmt"
+
+type S3Cmd struct {
+	mb      string
+	list    string
+	put     string
+	secrets string
+}
+
+func (s *S3Cmd) Run() error {
+	fmt.Println("Hello s3")
+	return nil
+}

--- a/nuv/s3_test.go
+++ b/nuv/s3_test.go
@@ -1,0 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package main

--- a/nuv/s3_test.go
+++ b/nuv/s3_test.go
@@ -16,3 +16,39 @@
 // under the License.
 //
 package main
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_readS3Secrets(t *testing.T) {
+
+	t.Run("should return error when unable to read secrets.json", func(t *testing.T) {
+		emptyConfig := fstest.MapFS{"/": {Mode: fs.ModeDir}}
+		_, err := readS3Secrets(emptyConfig)
+		assert.Error(t, err)
+	})
+
+	t.Run("should return s3Secrets when secrets.json is valid", func(t *testing.T) {
+		expected := s3SecretsJSON{
+			Id:     "some-id",
+			Key:    "some-key",
+			Region: "some-region",
+		}
+		secrets := `
+{
+	"id": "some-id",
+	"key": "some-key",
+	"region": "some-region"
+}`
+		fakeFS := fstest.MapFS{"secrets.json": {Data: []byte(secrets)}}
+
+		config, err := readS3Secrets(fakeFS)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, config)
+	})
+}


### PR DESCRIPTION
This PR adds the s3 subcommand as described in issue [#76](https://github.com/nuvolaris/nuvolaris/issues/76)

It will implement 4 commands:
- [] mb: to create new buckets
- [] list: to list files in buckets
- [] put: to upload files
- [] secrets: to configure the credentials to access s3

As I implement the commands I will update the tasks done