### PR TITLE
Add custom logger from kind with spinner animation

### DIFF
--- a/nuv/deploy.go
+++ b/nuv/deploy.go
@@ -19,7 +19,6 @@ package main
 
 import (
 	_ "embed"
-	"fmt"
 	"io/ioutil"
 )
 
@@ -33,22 +32,24 @@ type DeployCmd struct {
 
 // AfterApply is an hook that gets called after parsing the command but before Run is executed
 // used to run preflight checks
-func (d DeployCmd) AfterApply() error {
+func (d DeployCmd) AfterApply(logger *Logger) error {
 	if d.NoPreflightChecks {
 		return nil
 	}
+	logger.Info("Running Preflight checks...")
 	homedir, _ := GetHomeDir()
 
-	err := RunPreflightChecks(homedir)
+	err := RunPreflightChecks(logger, homedir)
 
 	if err != nil {
 		return err
 	}
+	logger.Info("Preflight checks passed!")
 	return nil
 }
 
-func (*DeployCmd) Run() error {
-	fmt.Println("Deploying Nuvolaris...")
+func (*DeployCmd) Run(logger *Logger) error {
+	logger.Info("Deploying Nuvolaris...")
 	ioutil.WriteFile("nuvolaris.yml", NuvolarisYml, 0600)
 	Task()
 	return nil

--- a/nuv/devcluster.go
+++ b/nuv/devcluster.go
@@ -21,10 +21,10 @@ type DevClusterCmd struct {
 	Action string `arg:"" name:"action" help:"create/destroy" type:"string"`
 }
 
-func (devClusterCmd *DevClusterCmd) Run() error {
+func (devClusterCmd *DevClusterCmd) Run(logger *Logger) error {
 	config, err := configKind()
 	if err != nil {
 		return err
 	}
-	return config.manageKindCluster(devClusterCmd.Action)
+	return config.manageKindCluster(logger, devClusterCmd.Action)
 }

--- a/nuv/kindcluster.go
+++ b/nuv/kindcluster.go
@@ -34,7 +34,7 @@ type KindConfig struct {
 	nuvolarisConfigDir   string
 	kindConfigFile       string
 	fullConfigPath       string
-	preflightChecks      func(string) error
+	preflightChecks      func(*Logger, string) error
 	kind                 func(...string) error
 }
 
@@ -60,11 +60,11 @@ func configKind() (*KindConfig, error) {
 	return &config, nil
 }
 
-func (config *KindConfig) manageKindCluster(action string) error {
+func (config *KindConfig) manageKindCluster(logger *Logger, action string) error {
 
 	switch action {
 	case "create":
-		if err := config.createCluster(); err != nil {
+		if err := config.createCluster(logger); err != nil {
 			return err
 		}
 	case "destroy":
@@ -77,7 +77,7 @@ func (config *KindConfig) manageKindCluster(action string) error {
 	return nil
 }
 
-func (config *KindConfig) createCluster() (err error) {
+func (config *KindConfig) createCluster(logger *Logger) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("error in create cluster: %w", err)
@@ -89,15 +89,15 @@ func (config *KindConfig) createCluster() (err error) {
 		return err
 	}
 	if clusterIsRunning {
-		fmt.Println("nuvolaris kind cluster is already running...skipping")
+		logger.Info("nuvolaris kind cluster is already running...skipping")
 		return nil
 	}
 
-	fmt.Println("running preflight checks")
-	if err = config.preflightChecks(config.homedir); err != nil {
+	logger.Info("Running Preflight checks...")
+	if err = config.preflightChecks(logger, config.homedir); err != nil {
 		return err
 	}
-	fmt.Println("preflight checks ok")
+	logger.Info("Preflight checks passed!")
 
 	_, err = GetOrCreateNuvolarisConfigDir()
 	if err != nil {
@@ -111,12 +111,12 @@ func (config *KindConfig) createCluster() (err error) {
 
 	config.fullConfigPath = fullConfigPath
 
-	fmt.Println("starting nuvolaris kind cluster...hang tight")
+	logger.Info("Starting nuvolaris kind cluster... hang tight")
 	if err = config.startCluster(); err != nil {
 		return err
 	}
 
-	fmt.Println("nuvolaris kind cluster started. Have a nice day! 👋")
+	logger.Info("Nuvolaris kind cluster started. Have a nice day! 👋")
 	return nil
 }
 

--- a/nuv/kindcluster_test.go
+++ b/nuv/kindcluster_test.go
@@ -73,7 +73,7 @@ func Example_preflightChecksNok() {
 	}
 	config.manageKindCluster(NewLogger(), "create")
 	// Output:
-	// running preflight checks
+	// Running Preflight checks...
 }
 
 func Example_successfullClusterStartFromScratch() {
@@ -97,12 +97,12 @@ func Example_successfullClusterStartFromScratch() {
 
 	config.manageKindCluster(NewLogger(), "create")
 	// Output:
-	// running preflight checks
-	// preflight checks ok
+	// Running Preflight checks...
+	// Preflight checks passed!
 	// nuvolaris config dir created
 	// kind.yaml written
-	// starting nuvolaris kind cluster...hang tight
-	// nuvolaris kind cluster started. Have a nice day! 👋
+	// Starting nuvolaris kind cluster... hang tight
+	// Nuvolaris kind cluster started. Have a nice day! 👋
 }
 
 func Example_destroyRunningCluster() {

--- a/nuv/kindcluster_test.go
+++ b/nuv/kindcluster_test.go
@@ -28,7 +28,7 @@ var homeDir, _ = GetHomeDir()
 func Example_devClusterWrongAction() {
 
 	config := KindConfig{}
-	config.manageKindCluster("delete")
+	config.manageKindCluster(NewLogger(), "delete")
 	// Output:
 	// did you mean nuv devcluster create/destroy?
 }
@@ -41,7 +41,7 @@ func Example_devClusterAlreadyRunning() {
 			return nil
 		},
 	}
-	config.manageKindCluster("create")
+	config.manageKindCluster(NewLogger(), "create")
 	// Output:
 	// nuvolaris kind cluster is already running...skipping
 }
@@ -55,7 +55,7 @@ func Example_multipleDevClustersRunningWithNuvolaris() {
 			return nil
 		},
 	}
-	config.manageKindCluster("create")
+	config.manageKindCluster(NewLogger(), "create")
 	// Output:
 	// nuvolaris kind cluster is already running...skipping
 }
@@ -67,11 +67,11 @@ func Example_preflightChecksNok() {
 		kind: func(...string) error {
 			return nil
 		},
-		preflightChecks: func(string) error {
+		preflightChecks: func(*Logger, string) error {
 			return fmt.Errorf("docker is not running")
 		},
 	}
-	config.manageKindCluster("create")
+	config.manageKindCluster(NewLogger(), "create")
 	// Output:
 	// running preflight checks
 }
@@ -85,7 +85,7 @@ func Example_successfullClusterStartFromScratch() {
 		nuvolarisConfigDir:   ".nuvolaris",
 		kindConfigFile:       "kind.yaml",
 		fullConfigPath:       "",
-		preflightChecks: func(string) error {
+		preflightChecks: func(*Logger, string) error {
 			return nil
 		},
 		kind: func(...string) error {
@@ -95,7 +95,7 @@ func Example_successfullClusterStartFromScratch() {
 	fullPath := filepath.Join(config.homedir, config.nuvolarisConfigDir)
 	os.RemoveAll(fullPath)
 
-	config.manageKindCluster("create")
+	config.manageKindCluster(NewLogger(), "create")
 	// Output:
 	// running preflight checks
 	// preflight checks ok
@@ -115,7 +115,7 @@ func Example_destroyRunningCluster() {
 		},
 	}
 
-	config.manageKindCluster("destroy")
+	config.manageKindCluster(NewLogger(), "destroy")
 	// Output:
 	// nuvolaris
 	// kind cluster nuvolaris destroyed
@@ -130,7 +130,7 @@ func Example_destroyClusterNotRunning() {
 		},
 	}
 
-	config.manageKindCluster("destroy")
+	config.manageKindCluster(NewLogger(), "destroy")
 	// Output:
 	// kind cluster nuvolaris not found...skipping
 }

--- a/nuv/kubeclient.go
+++ b/nuv/kubeclient.go
@@ -40,7 +40,7 @@ type KubeClient struct {
 	cfg             *rest.Config
 }
 
-func initClients(createDevcluster bool, k8sContext string) (*KubeClient, error) {
+func initClients(logger *Logger, createDevcluster bool, k8sContext string) (*KubeClient, error) {
 
 	if createDevcluster {
 		fmt.Println("Starting devcluster...")
@@ -48,7 +48,7 @@ func initClients(createDevcluster bool, k8sContext string) (*KubeClient, error) 
 		if err != nil {
 			return nil, err
 		}
-		err = cfg.manageKindCluster("create")
+		err = cfg.manageKindCluster(logger, "create")
 		if err != nil {
 			return nil, err
 		}

--- a/nuv/log/bufferpool.go
+++ b/nuv/log/bufferpool.go
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package log
+
+import (
+	"bytes"
+	"sync"
+)
+
+// BufferPool is a type safe sync.Pool of *byte.Buffer, guaranteed to be Reset
+type BufferPool struct {
+	sync.Pool
+}
+
+// NewBufferPool returns a new bufferPool
+func NewBufferPool() *BufferPool {
+	return &BufferPool{
+		sync.Pool{
+			New: func() interface{} {
+				// The Pool's New function should generally only return pointer
+				// types, since a pointer can be put into the return interface
+				// value without an allocation:
+				return new(bytes.Buffer)
+			},
+		},
+	}
+}
+
+// Get obtains a buffer from the pool
+func (b *BufferPool) Get() *bytes.Buffer {
+	return b.Pool.Get().(*bytes.Buffer)
+}
+
+// Put returns a buffer to the pool, resetting it first
+func (b *BufferPool) Put(x *bytes.Buffer) {
+	// only store small buffers to avoid pointless allocation
+	// avoid keeping arbitrarily large buffers
+	if x.Len() > 256 {
+		return
+	}
+	x.Reset()
+	b.Pool.Put(x)
+}

--- a/nuv/log/spinner.go
+++ b/nuv/log/spinner.go
@@ -1,0 +1,169 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package log
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+	"sync"
+	"time"
+)
+
+// custom CLI loading spinner for kind
+var spinnerFrames = []string{
+	"⠈⠁",
+	"⠈⠑",
+	"⠈⠱",
+	"⠈⡱",
+	"⢀⡱",
+	"⢄⡱",
+	"⢄⡱",
+	"⢆⡱",
+	"⢎⡱",
+	"⢎⡰",
+	"⢎⡠",
+	"⢎⡀",
+	"⢎⠁",
+	"⠎⠁",
+	"⠊⠁",
+}
+
+// Spinner is a simple and efficient CLI loading spinner used by kind
+// It is simplistic and assumes that the line length will not change.
+type Spinner struct {
+	stop    chan struct{} // signals writer goroutine to stop from Stop()
+	stopped chan struct{} // signals Stop() that the writer goroutine stopped
+	mu      *sync.Mutex   // protects the mutable bits
+	// below are protected by mu
+	running bool
+	writer  io.Writer
+	ticker  *time.Ticker // signals that it is time to write a frame
+	prefix  string
+	suffix  string
+	// format string used to write a frame, depends on the host OS / terminal
+	frameFormat string
+}
+
+// spinner implements writer
+var _ io.Writer = &Spinner{}
+
+// NewSpinner initializes and returns a new Spinner that will write to w
+// NOTE: w should be os.Stderr or similar, and it should be a Terminal
+func NewSpinner(w io.Writer) *Spinner {
+	frameFormat := "\x1b[?7l\r%s%s%s\x1b[?7h"
+	// toggling wrapping seems to behave poorly on windows
+	// in general only the simplest escape codes behave well at the moment,
+	// and only in newer shells
+	if runtime.GOOS == "windows" {
+		frameFormat = "\r%s%s%s"
+	}
+	return &Spinner{
+		stop:        make(chan struct{}, 1),
+		stopped:     make(chan struct{}),
+		mu:          &sync.Mutex{},
+		writer:      w,
+		frameFormat: frameFormat,
+	}
+}
+
+// SetPrefix sets the prefix to print before the spinner
+func (s *Spinner) SetPrefix(prefix string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.prefix = prefix
+}
+
+// SetSuffix sets the suffix to print after the spinner
+func (s *Spinner) SetSuffix(suffix string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.suffix = suffix
+}
+
+// Start starts the spinner running
+func (s *Spinner) Start() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// don't start if we've already started
+	if s.running {
+		return
+	}
+	// flag that we've started
+	s.running = true
+	// start / create a frame ticker
+	s.ticker = time.NewTicker(time.Millisecond * 100)
+	// spin in the background
+	go func() {
+		// write frames forever (until signaled to stop)
+		for {
+			for _, frame := range spinnerFrames {
+				select {
+				// prefer stopping, select this signal first
+				case <-s.stop:
+					func() {
+						s.mu.Lock()
+						defer s.mu.Unlock()
+						s.ticker.Stop()         // free up the ticker
+						s.running = false       // mark as stopped (it's fine to start now)
+						s.stopped <- struct{}{} // tell Stop() that we're done
+					}()
+					return // ... and stop
+				// otherwise continue and write one frame
+				case <-s.ticker.C:
+					func() {
+						s.mu.Lock()
+						defer s.mu.Unlock()
+						fmt.Fprintf(s.writer, s.frameFormat, s.prefix, frame, s.suffix)
+					}()
+				}
+			}
+		}
+	}()
+}
+
+// Stop signals the spinner to stop
+func (s *Spinner) Stop() {
+	s.mu.Lock()
+	if !s.running {
+		s.mu.Unlock()
+		return
+	}
+	// try to stop, do nothing if channel is full (IE already busy stopping)
+	s.stop <- struct{}{}
+	s.mu.Unlock()
+	// wait for stop to be finished
+	<-s.stopped
+}
+
+// Write implements io.Writer, interrupting the spinner and writing to
+// the inner writer
+func (s *Spinner) Write(p []byte) (n int, err error) {
+	// lock first, so nothing else can start writing until we are done
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// it the spinner is not running, just write directly
+	if !s.running {
+		return s.writer.Write(p)
+	}
+	// otherwise: we will rewrite the line first
+	if _, err := s.writer.Write([]byte("\r")); err != nil {
+		return 0, err
+	}
+	return s.writer.Write(p)
+}

--- a/nuv/log/term.go
+++ b/nuv/log/term.go
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package log
+
+import (
+	"io"
+	"os"
+	"runtime"
+
+	"github.com/mattn/go-isatty"
+)
+
+// a fake TTY type for testing that can only be implemented within this package
+type isTestFakeTTY interface {
+	isTestFakeTTY()
+}
+
+// IsTerminal returns true if the writer w is a terminal
+func IsTerminal(w io.Writer) bool {
+	// check for internal fake type we can use for testing.
+	if _, ok := (w).(isTestFakeTTY); ok {
+		return true
+	}
+	// check for real terminals
+	if v, ok := (w).(*os.File); ok {
+		return isatty.IsTerminal(v.Fd())
+	}
+	return false
+}
+
+// IsSmartTerminal returns true if the writer w is a terminal AND
+// we think that the terminal is smart enough to use VT escape codes etc.
+func IsSmartTerminal(w io.Writer) bool {
+	return isSmartTerminal(w, runtime.GOOS, os.LookupEnv)
+}
+
+func isSmartTerminal(w io.Writer, GOOS string, lookupEnv func(string) (string, bool)) bool {
+	// Not smart if it's not a tty
+	if !IsTerminal(w) {
+		return false
+	}
+
+	// getenv helper for when we only care about the value
+	getenv := func(e string) string {
+		v, _ := lookupEnv(e)
+		return v
+	}
+
+	// Explicit request for no ANSI escape codes
+	// https://no-color.org/
+	if _, set := lookupEnv("NO_COLOR"); set {
+		return false
+	}
+
+	// Explicitly dumb terminals are not smart
+	// https://en.wikipedia.org/wiki/Computer_terminal#Dumb_terminals
+	term := getenv("TERM")
+	if term == "dumb" {
+		return false
+	}
+	// st has some bug 🤷‍♂️
+	// https://github.com/kubernetes-sigs/kind/issues/1892
+	if term == "st-256color" {
+		return false
+	}
+
+	// On Windows WT_SESSION is set by the modern terminal component.
+	// Older terminals have poor support for UTF-8, VT escape codes, etc.
+	if GOOS == "windows" && getenv("WT_SESSION") == "" {
+		return false
+	}
+
+	// OK, we'll assume it's smart now, given no evidence otherwise.
+	return true
+}

--- a/nuv/log/types.go
+++ b/nuv/log/types.go
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package log
+
+// Logger defines the logging interface
+// It is roughly a subset of github.com/kubernetes/klog
+type Logger interface {
+	// Debug is used for debug messages
+	Debug(message string)
+	// Debugf is used to write a Printf style debug message
+	Debugf(format string, args ...interface{})
+
+	// Info is used for normal user facing messages
+	Info(message string)
+	// Infof is used to write a Printf style user facing status message
+	Infof(format string, args ...interface{})
+
+	// StartSpinner starts the loading spinner with a message
+	StartSpinner(status string)
+	//EndSpinner stops the spinner and displays a checkmark for success or fail state
+	EndSpinner(success bool)
+
+	//EndSpinnerMsg works like EndSpinner but changes the msg displayed next to the checkmark
+	EndSpinnerMsg(success bool, msg string)
+
+	// Wraps a function with the start and end spinner around
+	ActionWithSpinner(msg string, f func() bool)
+}

--- a/nuv/logger.go
+++ b/nuv/logger.go
@@ -1,0 +1,222 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/nuvolaris/nuvolaris-cli/nuv/log"
+)
+
+// Logger is the kind cli's log.Logger implementation
+type Logger struct {
+	writer     io.Writer
+	writerMu   sync.Mutex
+	bufferPool *log.BufferPool
+	// kind special additions
+	isSmartWriter bool
+
+	spinner       *log.Spinner
+	spinnerStatus string
+	// for controlling coloring etc
+	successFormat string
+	failureFormat string
+}
+
+var _ log.Logger = &Logger{}
+
+// Info is part of the log.NuvLogger interface
+func (l *Logger) Debug(message string) {
+	l.debug(message)
+}
+
+// Debugf is part of the log.NuvLogger interface
+func (l *Logger) Debugf(format string, args ...interface{}) {
+	l.debugf(format, args...)
+}
+
+// Info is part of the log.NuvLogger interface
+func (l *Logger) Info(message string) {
+	l.print(message)
+}
+
+// Infof is part of the log.NuvLogger interface
+func (l *Logger) Infof(format string, args ...interface{}) {
+	l.printf(format, args...)
+}
+
+func (l *Logger) ActionWithSpinner(msg string, f func() bool) {
+	l.StartSpinner(msg)
+	ok := f()
+	l.EndSpinner(ok)
+}
+
+// Start starts a new phase of the status, if attached to a terminal
+// there will be a loading spinner with this status
+func (l *Logger) StartSpinner(msg string) {
+	l.EndSpinner(true)
+	// set new status
+	l.spinnerStatus = msg
+	if l.spinner != nil {
+		l.spinner.SetSuffix(fmt.Sprintf(" %s ", l.spinnerStatus))
+		l.spinner.Start()
+	} else {
+		l.Infof(" • %s  ...\n", l.spinnerStatus)
+	}
+}
+
+// End completes the current status, ending any previous spinning and
+// marking the status as success or failure
+func (l *Logger) EndSpinner(success bool) {
+	if l.spinnerStatus == "" {
+		return
+	}
+
+	if l.spinner != nil {
+		l.spinner.Stop()
+		l.spinner.Write([]byte("\r"))
+		// fmt.Fprint(l.spinner.writer, "\r")
+	}
+	if success {
+		l.Infof(l.successFormat, l.spinnerStatus)
+	} else {
+		l.Infof(l.failureFormat, l.spinnerStatus)
+	}
+
+	l.spinnerStatus = ""
+}
+
+func (l *Logger) EndSpinnerMsg(success bool, msg string) {
+	if l.spinnerStatus == "" {
+		return
+	}
+	l.spinnerStatus = msg
+	l.EndSpinner(success)
+}
+
+// NewLogger returns the standard logger used by the CLI
+func NewLogger() *Logger {
+	var writer io.Writer = os.Stdout
+	if log.IsSmartTerminal(writer) {
+		writer = log.NewSpinner(writer)
+	}
+
+	l := &Logger{
+		bufferPool: log.NewBufferPool(),
+	}
+	l.setWriter(writer)
+
+	return l
+}
+
+// setWriter sets the output writer
+func (l *Logger) setWriter(w io.Writer) {
+	l.writerMu.Lock()
+	defer l.writerMu.Unlock()
+
+	l.writer = w
+	if v2, ok := w.(*log.Spinner); ok {
+		l.spinner = v2
+		l.isSmartWriter = ok
+		// use colored success / failure messages
+		l.successFormat = " \x1b[32m✓\x1b[0m %s\n"
+		l.failureFormat = " \x1b[31m✗\x1b[0m %s\n"
+	} else {
+		l.isSmartWriter = log.IsSmartTerminal(w)
+	}
+}
+
+// synchronized write to the inner writer
+func (l *Logger) write(p []byte) (n int, err error) {
+	l.writerMu.Lock()
+	defer l.writerMu.Unlock()
+	return l.writer.Write(p)
+}
+
+// writeBuffer writes buf with write, ensuring there is a trailing newline
+func (l *Logger) writeBuffer(buf *bytes.Buffer) {
+	// ensure trailing newline
+	if buf.Len() == 0 || buf.Bytes()[buf.Len()-1] != '\n' {
+		buf.WriteByte('\n')
+	}
+	// TODO: should we handle this somehow??
+	// Who logs for the logger? 🤔
+	_, _ = l.write(buf.Bytes())
+}
+
+// print writes a simple string to the log writer
+func (l *Logger) print(message string) {
+	buf := bytes.NewBufferString(message)
+	l.writeBuffer(buf)
+}
+
+// printf is roughly fmt.Fprintf against the log writer
+func (l *Logger) printf(format string, args ...interface{}) {
+	buf := l.bufferPool.Get()
+	fmt.Fprintf(buf, format, args...)
+	l.writeBuffer(buf)
+	l.bufferPool.Put(buf)
+}
+
+// addDebugHeader inserts the debug line header to buf
+func addDebugHeader(buf *bytes.Buffer) {
+	_, file, line, ok := runtime.Caller(3)
+	// lifted from klog
+	if !ok {
+		file = "???"
+		line = 1
+	} else {
+		if slash := strings.LastIndex(file, "/"); slash >= 0 {
+			path := file
+			file = path[slash+1:]
+			if dirsep := strings.LastIndex(path[:slash], "/"); dirsep >= 0 {
+				file = path[dirsep+1:]
+			}
+		}
+	}
+	buf.Grow(len(file) + 12) // we know at least this many bytes are needed
+	buf.WriteString("DEBUG: ")
+	buf.WriteString(file)
+	buf.WriteByte(':')
+	fmt.Fprintf(buf, "%d", line)
+	buf.WriteString(" - ")
+}
+
+// debug is like print but with a debug log header
+func (l *Logger) debug(message string) {
+	buf := l.bufferPool.Get()
+	addDebugHeader(buf)
+	buf.WriteString(message)
+	l.writeBuffer(buf)
+	l.bufferPool.Put(buf)
+}
+
+// debugf is like printf but with a debug log header
+func (l *Logger) debugf(format string, args ...interface{}) {
+	buf := l.bufferPool.Get()
+	addDebugHeader(buf)
+	fmt.Fprintf(buf, format, args...)
+	l.writeBuffer(buf)
+	l.bufferPool.Put(buf)
+}

--- a/nuv/main.go
+++ b/nuv/main.go
@@ -33,22 +33,24 @@ var ImageTag string = "0.2.0-trinity.22032018"
 var KubeContext string = "kind-nuvolaris"
 
 type CLI struct {
-	Deploy     DeployCmd     `cmd:"" help:"deploy a nuvolaris cluster"`
-	Destroy    DestroyCmd    `cmd:"" help:"destroy a nuvolaris cluster"`
-	Wsk        WskCmd        `cmd:"" passthrough:"" help:"wsk subcommand"`
-	Kops       KopsCmd       `cmd:"" passthrough:"" help:"kops subcommand"`
-	Task       TaskCmd       `cmd:"" help:"task subcommand"`
-	Kind       KindCmd       `cmd:"" help:"kind subcommand"`
-	Devcluster DevClusterCmd `cmd:"" help:"create or destroy kind k8s cluster"`
-	Setup      SetupCmd      `cmd:"" help:"setup nuvolaris"`
-	Scan       ScanCmd       `cmd:"" help:"scan subcommand"`
-	S3         S3Cmd         `cmd:"" name:"s3" help:"s3 subcommand"`
-	Wskprops   WskPropsCmd   `cmd:"" help:"setup a .wskprops file"`
-	Version kong.VersionFlag `short:"v" help:"show nuvolaris version"`
+	Deploy     DeployCmd        `cmd:"" help:"deploy a nuvolaris cluster"`
+	Destroy    DestroyCmd       `cmd:"" help:"destroy a nuvolaris cluster"`
+	Wsk        WskCmd           `cmd:"" passthrough:"" help:"wsk subcommand"`
+	Kops       KopsCmd          `cmd:"" passthrough:"" help:"kops subcommand"`
+	Task       TaskCmd          `cmd:"" help:"task subcommand"`
+	Kind       KindCmd          `cmd:"" help:"kind subcommand"`
+	Devcluster DevClusterCmd    `cmd:"" help:"create or destroy kind k8s cluster"`
+	Setup      SetupCmd         `cmd:"" help:"setup nuvolaris"`
+	Scan       ScanCmd          `cmd:"" help:"scan subcommand"`
+	S3         S3Cmd            `cmd:"" name:"s3" help:"s3 subcommand"`
+	Wskprops   WskPropsCmd      `cmd:"" help:"setup a .wskprops file"`
+	Version    kong.VersionFlag `short:"v" help:"show nuvolaris version"`
 }
 
 func main() {
 	cli := CLI{}
+	logger := NewLogger()
+
 	ctx := kong.Parse(&cli,
 		kong.Name(Name),
 		kong.Description(Description),
@@ -62,6 +64,7 @@ func main() {
 			"image_tag":    ImageTag,
 			"kube_context": KubeContext,
 		},
+		kong.Bind(logger),
 	)
 	err := ctx.Run()
 	ctx.FatalIfErrorf(err)

--- a/nuv/preflight.go
+++ b/nuv/preflight.go
@@ -33,6 +33,7 @@ type PreflightChecksPipeline struct {
 	dir               string
 	dockerData        string
 	err               error
+	logger            *Logger
 }
 
 type checkStep func(pd *PreflightChecksPipeline)
@@ -46,11 +47,11 @@ func (p *PreflightChecksPipeline) step(f checkStep) {
 
 // RunPreflightChecks performs preflight checks
 // checks docker version, available memory and dir paths
-func RunPreflightChecks(dir string) error {
+func RunPreflightChecks(logger *Logger, dir string) error {
 
 	// Preflight Checks pipeline
 	// TODO: keep skipDockerVersion and dryRun?
-	pp := PreflightChecksPipeline{skipDockerVersion: false, dryRun: false, dir: dir}
+	pp := PreflightChecksPipeline{skipDockerVersion: false, dryRun: false, dir: dir, logger: logger}
 
 	pp.step(extractDockerInfo)
 	pp.step(checkDockerMemory)
@@ -65,43 +66,52 @@ func extractDockerInfo(p *PreflightChecksPipeline) {
 }
 
 func checkDockerMemory(p *PreflightChecksPipeline) {
+	p.logger.StartSpinner("Is Docker running?")
 	var search = regexp.MustCompile(`Total Memory: (.*)`)
 	result := search.FindString(string(p.dockerData))
 	if result == "" {
+		p.logger.EndSpinner(false)
 		p.err = fmt.Errorf("docker is not running")
 		return
 	}
-	fmt.Println("docker is running...")
+	p.logger.EndSpinner(true)
+
+	p.logger.StartSpinner("Enough memory available? (min. 4GB)")
 	mem := strings.Split(result, ":")
 	memory := strings.TrimSpace(mem[1])
 	n, err := units.ParseStrictBytes(memory)
 	if err != nil {
 		p.err = err
+		p.logger.EndSpinner(false)
 		return
 	}
 	if n <= int64(MinDockerMem) {
 		p.err = fmt.Errorf("nuv needs 4GB memory allocatable on docker")
+		p.logger.EndSpinner(false)
 		return
 	}
-	fmt.Println("enough memory to allocate...")
+	p.logger.EndSpinner(true)
 }
 
 func ensureDockerVersion(p *PreflightChecksPipeline) {
 	if p.skipDockerVersion {
 		return
 	}
+	p.logger.StartSpinner("Check Docker version (min. " + MinDockerVersion + ")")
 	version, err := dockerVersion(p.dryRun)
 	if err != nil {
 		p.err = err
+		p.logger.EndSpinner(false)
 		return
 	}
 	vA := semver.New(MinDockerVersion)
 	vB := semver.New(strings.TrimSpace(version))
 	if vB.Compare(*vA) == -1 {
 		p.err = fmt.Errorf("installed docker version %s is no longer supported", vB)
+		p.logger.EndSpinner(false)
 		return
 	}
-	fmt.Printf("installed docker version %s ok...\n", vB)
+	p.logger.EndSpinner(true)
 }
 
 func isInHomePath(p *PreflightChecksPipeline) {
@@ -109,19 +119,23 @@ func isInHomePath(p *PreflightChecksPipeline) {
 	if p.dir == "" {
 		return
 	}
+	p.logger.StartSpinner("Work directory accessible?")
 	homePath, err := GetHomeDir()
 	if err != nil {
 		p.err = err
+		p.logger.EndSpinner(false)
 		return
 	}
 	dir, err := filepath.Abs(p.dir)
 	if err != nil {
 		p.err = err
+		p.logger.EndSpinner(false)
 		return
 	}
 	if !strings.HasPrefix(dir, homePath) {
 		p.err = fmt.Errorf("work directory %s should be below your home directory;\nthis is required to be accessible by Docker", dir)
+		p.logger.EndSpinner(false)
 		return
 	}
-	fmt.Println("dir tree ok...")
+	p.logger.EndSpinner(true)
 }

--- a/nuv/preflight_test.go
+++ b/nuv/preflight_test.go
@@ -18,73 +18,52 @@
 package main
 
 import (
-	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func Example_ensureDockerVersion() {
+func Test_ensureDockerVersion(t *testing.T) {
 	DryRunPush("19.03.5", "10.03.5", MinDockerVersion, "!no docker")
 
-	p := PreflightChecksPipeline{dryRun: true}
+	p := PreflightChecksPipeline{dryRun: true, logger: NewLogger()}
 	p.step(ensureDockerVersion)
-	fmt.Println(p.err)
+	assert.NoError(t, p.err)
 
-	p = PreflightChecksPipeline{dryRun: true}
+	p = PreflightChecksPipeline{dryRun: true, logger: NewLogger()}
 	p.step(ensureDockerVersion)
-	fmt.Println(p.err)
+	assert.Error(t, p.err)
 
-	p = PreflightChecksPipeline{dryRun: true}
+	p = PreflightChecksPipeline{dryRun: true, logger: NewLogger()}
 	p.step(ensureDockerVersion)
-	fmt.Println(p.err)
+	assert.NoError(t, p.err)
 
-	p = PreflightChecksPipeline{dryRun: true}
+	p = PreflightChecksPipeline{dryRun: true, logger: NewLogger()}
 	p.step(ensureDockerVersion)
-	fmt.Println(p.err)
-	// Output:
-	// docker version --format {{.Server.Version}}
-	// installed docker version 19.3.5 ok...
-	// <nil>
-	// docker version --format {{.Server.Version}}
-	// installed docker version 10.3.5 is no longer supported
-	// docker version --format {{.Server.Version}}
-	// installed docker version 18.6.3-ce ok...
-	// <nil>
-	// docker version --format {{.Server.Version}}
-	// no docker
+	assert.Error(t, p.err)
 }
 
-func Example_isInHomePath() {
+func Test_isInHomePath(t *testing.T) {
 	homedir, _ := GetHomeDir()
-	p := PreflightChecksPipeline{dir: homedir}
+	p := PreflightChecksPipeline{dir: homedir, logger: NewLogger()}
 	p.step(isInHomePath)
-	fmt.Println(p.err)
+	assert.NoError(t, p.err)
 
-	p = PreflightChecksPipeline{dir: "/var/run"}
+	p = PreflightChecksPipeline{dir: "/var/run", logger: NewLogger()}
 	p.step(isInHomePath)
-	fmt.Println(p.err)
+	assert.Error(t, p.err)
 
-	p = PreflightChecksPipeline{dir: ""}
+	p = PreflightChecksPipeline{dir: "", logger: NewLogger()}
 	p.step(isInHomePath)
-	fmt.Println(p.err)
-	// Output:
-	// dir tree ok...
-	// <nil>
-	// work directory /var/run should be below your home directory;
-	// this is required to be accessible by Docker
-	// <nil>
+	assert.NoError(t, p.err)
 }
 
-func Example_checkDockerMemory() {
-	p := PreflightChecksPipeline{dockerData: "\nTotal Memory: 11GiB\n"}
+func Test_checkDockerMemory(t *testing.T) {
+	p := PreflightChecksPipeline{dockerData: "\nTotal Memory: 11GiB\n", logger: NewLogger()}
 	p.step(checkDockerMemory)
-	fmt.Println(p.err)
+	assert.NoError(t, p.err)
 
-	p = PreflightChecksPipeline{dockerData: "\nTotal Memory: 3GiB\n"}
+	p = PreflightChecksPipeline{dockerData: "\nTotal Memory: 3GiB\n", logger: NewLogger()}
 	p.step(checkDockerMemory)
-	fmt.Println(p.err)
-	// Output:
-	// docker is running...
-	// enough memory to allocate...
-	// <nil>
-	// docker is running...
-	// nuv needs 4GB memory allocatable on docker
+	assert.Error(t, p.err)
 }

--- a/nuv/setup.go
+++ b/nuv/setup.go
@@ -24,6 +24,6 @@ type SetupCmd struct {
 	Context    string `default:"${kube_context}" help:"kubernetes context from kubeconfig"`
 }
 
-func (setupCmd *SetupCmd) Run() error {
-	return setupNuvolaris(setupCmd)
+func (setupCmd *SetupCmd) Run(logger *Logger) error {
+	return setupNuvolaris(logger, setupCmd)
 }

--- a/nuv/setup_nuvolaris.go
+++ b/nuv/setup_nuvolaris.go
@@ -27,6 +27,7 @@ type SetupPipeline struct {
 	k8sContext          string
 	operatorDockerImage string
 	err                 error
+	logger              *Logger
 }
 
 type setupStep func(sp *SetupPipeline)
@@ -39,11 +40,12 @@ func (sp *SetupPipeline) step(f setupStep) {
 	time.Sleep(2 * time.Second)
 }
 
-func setupNuvolaris(cmd *SetupCmd) error {
+func setupNuvolaris(logger *Logger, cmd *SetupCmd) error {
 	imgTag := cmd.ImageTag
 
 	sp := SetupPipeline{
 		operatorDockerImage: "ghcr.io/nuvolaris/nuvolaris-operator:" + imgTag,
+		logger:              logger,
 	}
 
 	sp.createDevcluster = cmd.Devcluster
@@ -66,7 +68,7 @@ func setupNuvolaris(cmd *SetupCmd) error {
 }
 
 func assertNuvolarisClusterConfig(sp *SetupPipeline) {
-	sp.kubeClient, sp.err = initClients(sp.createDevcluster, sp.k8sContext)
+	sp.kubeClient, sp.err = initClients(sp.logger, sp.createDevcluster, sp.k8sContext)
 }
 
 func createNuvolarisNamespace(sp *SetupPipeline) {

--- a/nuv/setup_wskprops.go
+++ b/nuv/setup_wskprops.go
@@ -26,6 +26,7 @@ type WskPropsPipeline struct {
 	k8sContext string
 	apihost    string
 	err        error
+	logger     *Logger
 }
 
 type wskSetupStep func(sp *WskPropsPipeline)
@@ -37,8 +38,10 @@ func (wsp *WskPropsPipeline) wStep(f wskSetupStep) {
 	f(wsp)
 }
 
-func setupWskProps(cmd *WskPropsCmd) error {
-	wsp := WskPropsPipeline{}
+func setupWskProps(logger *Logger, cmd *WskPropsCmd) error {
+	wsp := WskPropsPipeline{
+		logger: logger,
+	}
 	if len(cmd.Context) == 0 {
 		config, err := getK8sConfig()
 		if err != nil {
@@ -59,7 +62,7 @@ func setupWskProps(cmd *WskPropsCmd) error {
 }
 
 func assertClusterConfig(wsp *WskPropsPipeline) {
-	wsp.kubeClient, wsp.err = initClients(false, wsp.k8sContext)
+	wsp.kubeClient, wsp.err = initClients(wsp.logger, false, wsp.k8sContext)
 }
 
 func readConfigMap(wsp *WskPropsPipeline) {

--- a/nuv/wskprops.go
+++ b/nuv/wskprops.go
@@ -21,6 +21,6 @@ type WskPropsCmd struct {
 	Context string `help:"Kubernetes context from .kubeconfig " type:"string"`
 }
 
-func (s *WskPropsCmd) Run() error {
-	return setupWskProps(s)
+func (s *WskPropsCmd) Run(logger *Logger) error {
+	return setupWskProps(logger, s)
 }


### PR DESCRIPTION
This PR adds a logger with a Info, Debug, StartSpinner and EndSpinner methods, similarly to kind's logger. (Issue #18)

It has to be passed as a parameter using Kong.Bind, making it available to any hooks and commands Run functions.
For now it changes the preflight checks output and some small logs.

The logger.Debug method will print only if nuv is compiled in Debug Mode. (TBD soon)

As of now the new preflight logs look like this, with the `nuv devcluster create`, but the rest of the commands still have to be updated.

![image](https://user-images.githubusercontent.com/11616936/159890474-3c682684-d0f6-4773-ae16-98df401de5bc.png)

We can discuss if it's a welcome change and what to add or if not needed.